### PR TITLE
vulns: add support for RHEL 9 for Edge in os-pkgs scanner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/ddtrivy
 
 go 1.24.0
 
-replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20250526103259-ac597e6e8b50
+replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20250715150938-0ecdc33e2882
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/CycloneDX/cyclonedx-go v0.9.2 h1:688QHn2X/5nRezKe2ueIVCt+NRqf7fl3AVQk+vaFcIo=
 github.com/CycloneDX/cyclonedx-go v0.9.2/go.mod h1:vcK6pKgO1WanCdd61qx4bFnSsDJQ6SbM2ZuMIgq86Jg=
-github.com/DataDog/trivy v0.0.0-20250526103259-ac597e6e8b50 h1:aDsW5NIbXbcB+HRu7tpt2GYLy9NlH5qtC2prx2AUJaE=
-github.com/DataDog/trivy v0.0.0-20250526103259-ac597e6e8b50/go.mod h1:PTxRTPpO/cM2OqNLPPKVGtLhEBhORyrXT6mAjplzsRA=
+github.com/DataDog/trivy v0.0.0-20250715150938-0ecdc33e2882 h1:Ys5qczIOrNx5nsBhKIuQEb21qvo5nHesp694M3Enddk=
+github.com/DataDog/trivy v0.0.0-20250715150938-0ecdc33e2882/go.mod h1:PTxRTPpO/cM2OqNLPPKVGtLhEBhORyrXT6mAjplzsRA=
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible h1:juIaKLLVhqzP55d8x4cSVgwyQv76Z55/fRv/UBr2KkQ=

--- a/vulns.go
+++ b/vulns.go
@@ -64,6 +64,7 @@ var osPkgDirs = []string{
 	"var/lib/dpkg/*",
 	"var/lib/rpm/*",
 	"usr/lib/sysimage/rpm/*",
+	"usr/share/rpm/*", // RHEL 9 for Edge
 	"lib/apk/db/*",
 	"aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/*",
 	"aarch64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/*",


### PR DESCRIPTION
This change adds support for RHEL 9 for Edge in os-pkgs scanner.

In RHEL 9 for Edge, /var/lib/rpm is a symlink to /usr/share/rpm.