### PR TITLE
go.mod: bump Trivy to the latest djc/main-dd-069 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/DataDog/ddtrivy
 
 go 1.25.6
 
-replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20260223152445-a9b26703ce6a
+replace github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20260513095541-82b34c058aad
 
 require (
-	github.com/aquasecurity/trivy v0.63.0
+	github.com/aquasecurity/trivy v0.69.1
 	github.com/aquasecurity/trivy-db v0.0.0-20251222105351-a833f47f8f0d
 	github.com/aquasecurity/trivy-java-db v0.0.0-20250520062418-66df85428c9e
 	github.com/google/go-containerregistry v0.20.7

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/CycloneDX/cyclonedx-go v0.9.3 h1:Pyk/lwavPz7AaZNvugKFkdWOm93MzaIyWmBwmBo3aUI=
 github.com/CycloneDX/cyclonedx-go v0.9.3/go.mod h1:vcK6pKgO1WanCdd61qx4bFnSsDJQ6SbM2ZuMIgq86Jg=
-github.com/DataDog/trivy v0.0.0-20260223152445-a9b26703ce6a h1:FUGhGJQjldwEp8kewvt4MeEmcmRc+EvkbMuUJ3XQN50=
-github.com/DataDog/trivy v0.0.0-20260223152445-a9b26703ce6a/go.mod h1:2cDQBIACLxt3NpCZ0Sthx4kLp9QmaiZC/5+fPP5Bz7Q=
+github.com/DataDog/trivy v0.0.0-20260513095541-82b34c058aad h1:oLz94OUJAQ7cscRNwzRUzTW6YytliqdBoOiw5ppshP4=
+github.com/DataDog/trivy v0.0.0-20260513095541-82b34c058aad/go.mod h1:2cDQBIACLxt3NpCZ0Sthx4kLp9QmaiZC/5+fPP5Bz7Q=
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/GoogleCloudPlatform/docker-credential-gcr/v2 v2.1.30 h1:LZKiFW/Mmr5ohlGs/2UmNlv+E0sWoa3lXqbJ8ZKwwDY=

--- a/vulns_test.go
+++ b/vulns_test.go
@@ -109,7 +109,7 @@ func TestDisablesAnalyzersIsComplete(t *testing.T) {
 
 func TestFastOSScan(t *testing.T) {
 	options := TrivyOptionsOS(1)
-	assert.Equal(t, options.WalkerOption.OnlyDirs, osPkgDirs)
+	assert.Nil(t, options.WalkerOption.OnlyDirs)
 }
 
 func TestLooselyCompareAnalyzers(t *testing.T) {


### PR DESCRIPTION
This change bumps Trivy to the latest djc/main-dd-069 branch.

It includes the change which stable-sorts CycloneDX properties by Name only
so DiffIDs (and RepoDigest/RepoTag) keep their input order in generated SBOMs.